### PR TITLE
free(): invalid pointer when empty recipe.txt

### DIFF
--- a/common/file/reader.c2
+++ b/common/file/reader.c2
@@ -71,7 +71,7 @@ public func bool Reader.open(Reader* file, const char* filename) {
 }
 
 public func void Reader.close(Reader* file) {
-    if (file.region) {
+    if (file.size) {
         stdlib.free(file.region);
         file.region = nil;
     }


### PR DESCRIPTION
If the recipe.txt is completely empty,
a free on Reader.region,
which holds a pointer to the global variable "empty"
is performed.

I changed it to check Reader.size instead.
No more "free(): invalid pointer" and the tests ran just like before.